### PR TITLE
Skip chunk stage to preserve source file list

### DIFF
--- a/com.oxygenxml.export.map/build.xml
+++ b/com.oxygenxml.export.map/build.xml
@@ -3,6 +3,7 @@
   
   <target name="dita2exportmap.init">
     <property name="preprocess.copy-image.skip" value="true"/>
+    <property name="preprocess.chunk.skip" value="true"/>
     <condition property="args.rellinks" value="nofamily">
       <not><isset property="args.rellinks"/></not>
     </condition>


### PR DESCRIPTION
When the @chunk attribute is applied within a map (for instance with the value `to-content`) some files are missing in .job.xml and thus in the target archive. Chunking could be disabled entirely to prevent such issues.

Tested on Windows 10, with DITA-OT 2.3.3 and 3.2 and generate.copy.outer set to "3".